### PR TITLE
Provide an option to load a bootstrap file to setup project specific php config

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,24 @@ config:
                     params:               []
 ```
 
+## Custom application logic
+
+When using custom doctrine types doctrine will produce an error that the type is not know. This can be solved by providing a bootstrap file to register the custom doctrine type.
+
+bootstrap.php
+```php
+<?php
+
+require_once '../vendor/autoload.php';
+
+\Doctrine\DBAL\Types\Type::addType('custom_type', 'Namespace\Of\The\Custom\Type');
+```
+
+Then provide the bootstrap file to the run command:
+
+```bash
+bin/neuralyzer run --db test_db -u root -p root -b bootstrap.php
+```
 
 ## Development
 Neuralyzer uses [Robo](https://robo.li) to run its tests (via Docker) and build its phar.

--- a/src/Console/Commands/RunCommand.php
+++ b/src/Console/Commands/RunCommand.php
@@ -19,6 +19,7 @@ namespace Edyan\Neuralyzer\Console\Commands;
 
 use Edyan\Neuralyzer\Configuration\Reader;
 use Edyan\Neuralyzer\Utils\DBUtils;
+use Edyan\Neuralyzer\Utils\FileLoader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -141,7 +142,13 @@ class RunCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Set the mode : batch or queries',
                 'batch'
-            );
+            )->addOption(
+                'bootstrap',
+                'b',
+                InputOption::VALUE_REQUIRED,
+                'Provide a bootstrap file to load a custom setup before executing the command. Format /path/to/bootstrap.php'
+            )
+        ;
     }
 
     /**
@@ -154,6 +161,10 @@ class RunCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        if (!empty($input->getOption('bootstrap'))) {
+            FileLoader::checkAndLoad($input->getOption('bootstrap'));
+        }
+
         // Throw an exception immediately if we dont have the required DB parameter
         if (empty($input->getOption('db'))) {
             throw new \InvalidArgumentException('Database name is required (--db)');

--- a/src/Utils/FileLoader.php
+++ b/src/Utils/FileLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Edyan\Neuralyzer\Utils;
+
+class FileLoader
+{
+    /**
+     * Checks if a PHP sourcefile is readable and loads it.
+     *
+     * @param string $filename
+     *
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public static function checkAndLoad($filename)
+    {
+        $includePathFilename = \stream_resolve_include_path($filename);
+
+        // As a fallback, PHP looks in the directory of the file executing the stream_resolve_include_path function.
+        // We don't want to load the Test.php file here, so skip it if it found that.
+        // PHP prioritizes the include_path setting, so if the current directory is in there, it will first look in the
+        // current working directory.
+        $localFile = __DIR__ . DIRECTORY_SEPARATOR . $filename;
+
+        $isReadable = @\fopen($includePathFilename, 'r') !== false;
+
+        if (!$includePathFilename || !$isReadable || $includePathFilename === $localFile) {
+            throw new \Exception(\sprintf('Cannot open file "%s".' . "\n", $filename));
+        }
+
+        require_once $includePathFilename;
+
+        return $includePathFilename;
+    }
+}


### PR DESCRIPTION
This PR adds the possibility to provide a `bootstrap.php` file to prepare some php specific config. Same way that you can specify a bootstrap file for your phpunit testsuite.

I've implemented this feature because our database uses some custom doctrine type and the dbal fails when requesting the table info.

```
Error anonymizing st_mails. Message was : Unknown column type "phone_number" requested. Any Doctrine type that you use has to be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a list of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If this error occurs during database introspection then you might have forgotten to register all database types for a Doctrine Type. Use AbstractPlatform#registerDoctrineTypeMapping() or have your custom types implement Type#getMappedDatabaseTypes(). If the type name is empty you might have a problem with the cache or forgot some mapping information.
```

This is solved by creating this bootstrap file and provide it to the run command.

```php
<?php
require_once './vendor/autoload.php';

\Doctrine\DBAL\Types\Type::addType('phone_number', 'Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType');
```

```
neuralyzer run *extra options* -b bootstrap.php
```