### PR TITLE
Return correct exit code if error occurred

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - sh -c "if [ '$DB_DRIVER' = 'pdo_pgsql' ]; then sudo /etc/init.d/postgresql restart; fi"
   # Mysql
   - sh -c "if [ '$DB_DRIVER' = 'pdo_mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS test_db;'; fi"
+  - sh -c "if [ '$DB_DRIVER' = 'pdo_mysql' ]; then mysql -e \"SET GLOBAL sql_mode ='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'\"; fi"
 
 before_script:
   - composer install --no-interaction --prefer-source

--- a/tests/Console/Commands/RunCommandTest.php
+++ b/tests/Console/Commands/RunCommandTest.php
@@ -140,4 +140,27 @@ class RunCommandTest extends AbstractConfigurationDB
             '--config' => __DIR__ . '/../../_files/config.right.notable.yaml'
         ]);
     }
+
+    public function testExecuteErrorCode()
+    {
+        $this->createPrimary();
+        $application = new Application();
+        $application->add(new Command());
+
+        // We mock the DialogHelper
+        $command = $application->find('run');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            '--driver' => getenv('DB_DRIVER'),
+            '--db' => getenv('DB_NAME'),
+            '--user' => getenv('DB_USER'),
+            '--host' => getenv('DB_HOST'),
+            '--password' => getenv('DB_PASSWORD'),
+            '--config' => __DIR__ . '/../../_files/config.wrongfieldvalue.yaml',
+            '--mode' => 'queries',
+        ]);
+
+        $this->assertSame(1, $commandTester->getStatusCode());
+    }
 }

--- a/tests/_files/config.wrongfieldvalue.yaml
+++ b/tests/_files/config.wrongfieldvalue.yaml
@@ -1,0 +1,8 @@
+guesser_version: 1.0.0b
+entities:
+    guestbook:
+        cols:
+            username: { method: sentence, params: [8] }
+            content: { method: sentence, params: [20] }
+            created: { method: date, params: [Y-m-d] }
+            an_integer: { method: sentence, params: [8] }


### PR DESCRIPTION
Currently the command returns exit code 0 even when there were exceptions during the anonymize process. I've changed this if any of the anonymize tables fails, the command will exit with error code 1.

This is important if you run the neuralyzer command during a build or automated script (like ansible)