### PR TITLE
Allow the usage of unique faker data

### DIFF
--- a/src/Anonymizer/DB.php
+++ b/src/Anonymizer/DB.php
@@ -413,7 +413,7 @@ class DB extends AbstractAnonymizer
             $this->checkColIsInEntity($colName);
 
             $data = \call_user_func_array(
-                [$this->faker, $colProps['method']],
+                [$this->getFakerObject($this->entity, $colName, $colProps), $colProps['method']],
                 $colProps['params']
             );
 

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -96,6 +96,7 @@ class ConfigDefinition implements ConfigurationInterface
                                 ->prototype('array')
                                     ->children()
                                         ->scalarNode('method')->isRequired()->end()
+                                        ->booleanNode('unique')->defaultFalse()->info('Set this option to true to use the faker->unique() generator')->end()
                                         ->arrayNode('params')
                                             ->defaultValue([])
                                             ->prototype('variable')->end()


### PR DESCRIPTION
This PR adds the ability to use the unique generator from the faker library. This allows to generate unique emails during the anonymisation

example:
```
...
entities:
    user_table:
        cols:
            email: { method: email, unique: true }
```

~~EDIT: Marked this pr as WIP as it seems that the fake data is not yet unique for the whole entity~~