### PR TITLE
Move include of bootstrap file down to avoid conflicts with loaded classes

### DIFF
--- a/src/Console/Commands/RunCommand.php
+++ b/src/Console/Commands/RunCommand.php
@@ -190,10 +190,6 @@ class RunCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
-        if (!empty($input->getOption('bootstrap'))) {
-            FileLoader::checkAndLoad($input->getOption('bootstrap'));
-        }
-
         // Throw an exception immediately if we don't have the required DB parameter
         if (empty($input->getOption('db'))) {
             throw new \InvalidArgumentException('Database name is required (--db)');
@@ -236,6 +232,10 @@ class RunCommand extends Command
         $this->db->setMode($this->input->getOption('mode'));
         $this->db->setPretend($this->input->getOption('pretend'));
         $this->db->setReturnRes($this->input->getOption('sql'));
+
+        if (!empty($input->getOption('bootstrap'))) {
+            FileLoader::checkAndLoad($input->getOption('bootstrap'));
+        }
 
         $stopwatch = new Stopwatch();
         $stopwatch->start('Neuralyzer');


### PR DESCRIPTION
I've added the bootstrap file support in #12. But loading it to early can create conflicts with the package autoloaded classes. So loading the bootstrap file later in the process fixes this issue