### PR TITLE
Anonymize of an empty table shouldn't trigger a non-zero exitcode

### DIFF
--- a/src/Console/Commands/RunCommand.php
+++ b/src/Console/Commands/RunCommand.php
@@ -268,7 +268,7 @@ class RunCommand extends Command
         if ($total === 0) {
             $this->output->writeln("<info>$table is empty</info>");
 
-            return false;
+            return true;
         }
 
         $bar = new ProgressBar($this->output, $total);


### PR DESCRIPTION
Printing the warning/info should be enough and the exitcode should still be zero imo